### PR TITLE
[TSK-33] Feat: 리프레시 토큰 제거를 이용한 logout 구현

### DIFF
--- a/src/main/java/com/walletguardians/walletguardiansapi/global/auth/controller/AuthController.java
+++ b/src/main/java/com/walletguardians/walletguardiansapi/global/auth/controller/AuthController.java
@@ -2,10 +2,15 @@ package com.walletguardians.walletguardiansapi.global.auth.controller;
 
 import com.walletguardians.walletguardiansapi.domain.user.dto.request.UserLoginRegister;
 import com.walletguardians.walletguardiansapi.domain.user.dto.request.UserRegisterRequest;
+import com.walletguardians.walletguardiansapi.global.auth.CustomUserDetails;
 import com.walletguardians.walletguardiansapi.global.auth.jwt.dto.TokenDto;
+import com.walletguardians.walletguardiansapi.global.auth.jwt.service.JwtService;
 import com.walletguardians.walletguardiansapi.global.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,17 +21,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
 
+  private final JwtService jwtService;
   private final AuthService authService;
 
   @PostMapping("/sign-up")
-  public ResponseEntity<String> register(@RequestBody UserRegisterRequest userRegisterRequest) {
-    authService.registerUser(userRegisterRequest);
+  public ResponseEntity<String> signUp(@RequestBody UserRegisterRequest userRegisterRequest) {
+    authService.signUpUser(userRegisterRequest);
     return ResponseEntity.ok().body("성공적으로 회원등록이 완료되었습니다.");
   }
 
   @PostMapping("/login")
   public ResponseEntity<TokenDto> login(@RequestBody UserLoginRegister userLoginRegister) {
     return ResponseEntity.ok().body(authService.login(userLoginRegister));
+  }
+
+  @DeleteMapping("/log-out")
+  public ResponseEntity<String> logout(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+      HttpServletRequest request) {
+    String accessToken = jwtService.extractAccessToken(request)
+        .filter(jwtService::validateToken)
+        .orElse(null);
+    return authService.logout(accessToken, customUserDetails.getUsername()); //username = email
   }
 
 }

--- a/src/main/java/com/walletguardians/walletguardiansapi/global/auth/controller/AuthController.java
+++ b/src/main/java/com/walletguardians/walletguardiansapi/global/auth/controller/AuthController.java
@@ -24,7 +24,7 @@ public class AuthController {
   private final JwtService jwtService;
   private final AuthService authService;
 
-  @PostMapping("/sign-up")
+  @PostMapping("/signup")
   public ResponseEntity<String> signUp(@RequestBody UserRegisterRequest userRegisterRequest) {
     authService.signUpUser(userRegisterRequest);
     return ResponseEntity.ok().body("성공적으로 회원등록이 완료되었습니다.");
@@ -35,7 +35,7 @@ public class AuthController {
     return ResponseEntity.ok().body(authService.login(userLoginRegister));
   }
 
-  @DeleteMapping("/log-out")
+  @DeleteMapping("/logout")
   public ResponseEntity<String> logout(@AuthenticationPrincipal CustomUserDetails customUserDetails,
       HttpServletRequest request) {
     String accessToken = jwtService.extractAccessToken(request)

--- a/src/main/java/com/walletguardians/walletguardiansapi/global/auth/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/walletguardians/walletguardiansapi/global/auth/jwt/repository/RefreshTokenRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+  void deleteByUserEmail(String userEmail);
+
 }

--- a/src/main/java/com/walletguardians/walletguardiansapi/global/auth/jwt/service/JwtService.java
+++ b/src/main/java/com/walletguardians/walletguardiansapi/global/auth/jwt/service/JwtService.java
@@ -155,4 +155,8 @@ public class JwtService {
     refreshTokenRepository.save(refreshTokenEntity);
   }
 
+  public void deleteRefreshToken(String email) {
+    refreshTokenRepository.deleteByUserEmail(email);
+  }
+
 }

--- a/src/main/java/com/walletguardians/walletguardiansapi/global/auth/service/AuthService.java
+++ b/src/main/java/com/walletguardians/walletguardiansapi/global/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import com.walletguardians.walletguardiansapi.global.auth.jwt.dto.TokenDto;
 import com.walletguardians.walletguardiansapi.global.auth.jwt.service.JwtService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -24,7 +25,7 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
 
   @Transactional
-  public void registerUser(UserRegisterRequest userRegisterRequest) {
+  public void signUpUser(UserRegisterRequest userRegisterRequest) {
     User user = userRepository.save(userRegisterRequest.toUserEntity());
     user.encodePassword(passwordEncoder);
   }
@@ -38,6 +39,17 @@ public class AuthService {
     }
 
     return jwtService.signIn(userLoginRegister.getEmail(), userLoginRegister.getPassword());
+  }
+
+  @Transactional
+  public ResponseEntity<String> logout(String accessToken, String email) {
+    boolean expiration = jwtService.validateToken(accessToken);
+    if (expiration) {
+      jwtService.deleteRefreshToken(email);
+    } else {
+      throw new IllegalArgumentException("이미 권한이 없는 토큰 보유자입니다.");
+    }
+    return ResponseEntity.ok("로그아웃 완료");
   }
 
 }


### PR DESCRIPTION
## ✅ 작업 내용
로그인과 회원가입을 제외한 모든 url에서 토큰이 필요하다는 점을 이용하여 로그아웃 시 테이블 안에 보관하던 리프레시 토큰을 제거하는 방식을 통해 구현해 보았습니다.

## 🤔 고민 했던 부분
리프레시 토큰이 없으면 그걸로 로그아웃이 끝났다고 할 수 있는가에 대해 생각해 보았습니다. 
제 생각으로는 로그아웃을 진행할 때  프론트에서도 자체적으로 보관하고 있던 액세스 토큰과 리프레시 토큰을 제거한다면 토큰 유효성 검사에서 걸리게 됩니다. 하지만 혹시 모를 리프레시 토큰 탈취의 경우를 고려하여 서버에 저장되어 있는 리프레시 토큰을 제거한다면 리프레시 토큰을 비교, 검사하지 못하므로 에러를 띄우게 됩니다.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**